### PR TITLE
$scope.video.* to $scope.video.value.*

### DIFF
--- a/js/app/main.js
+++ b/js/app/main.js
@@ -659,6 +659,7 @@
 	{
 		return function ( d ) {
 
+			if(!d) return;
 			var duration = d.split('M'); // PT35M2S
 
 			duration[0] = Number(duration[0].slice(2));
@@ -742,9 +743,9 @@
 				};
 
 				if ( $rootScope.settings.adblockoverride ) {
-					$scope.link = $scope.video.doc.link+"&adblock="+$rootScope.settings.adblocksecret;
+					$scope.link = $scope.video.value.link+"&adblock="+$rootScope.settings.adblocksecret;
 				} else {
-					$scope.link = $scope.video.doc.link;
+					$scope.link = $scope.video.value.link;
 				}
 
 			}

--- a/templates/item.html
+++ b/templates/item.html
@@ -1,16 +1,16 @@
 <div class="thumbnail"
 	 ng-if="video.id"
-	 ng-class="{'muted':video.doc.muted,'watched':video.doc.watched}">
+	 ng-class="{'muted':video.value.muted,'watched':video.value.watched}">
 	<div class="img-container">
-		<img src="{{video.thumbnail.medium}}"/>
+		<img src="{{video.value.thumbnail.medium}}"/>
 
-		<div class="duration">{{ video.duration | duration }}</div>
+		<div class="duration">{{ video.value.duration | duration }}</div>
 	</div>
 
 	<a href="{{ link }}"
 	   ng-mouseup="watch($event)"
 	   target="video-{{ video.id }}"
-	   title="{{video.title}}">
+	   title="{{video.value.title}}">
 		<div class="img-container-overlay"></div>
 	</a>
 
@@ -38,16 +38,16 @@
 			<a href="{{ link }}"
 			   ng-mouseup="watch($event)"
 			   target="video-{{ video.id }}"
-			   title="{{video.title}}">{{video.title}}</a>
+			   title="{{video.value.title}}">{{video.value.title}}</a>
 		</div>
 		<p class="author text-muted">
-			by <a ng-href="{{video.authorlink}}">{{video.author}}</a>
+			by <a ng-href="{{video.value.authorlink}}">{{video.value.author}}</a>
 		</p>
 
 		<p class="time">
-			<abbr class="timeago" title="{{video.published}}"></abbr>
-			<abbr title='{{video.published | timestamp | date:medium}}'>
-				<time-ago from-time='{{video.published | timestamp}}'></time-ago>
+			<abbr class="timeago" title="{{video.value.published}}"></abbr>
+			<abbr title='{{video.value.published | timestamp | date:medium}}'>
+				<time-ago from-time='{{video.value.published | timestamp}}'></time-ago>
 			</abbr>
 		</p>
 	</div>


### PR DESCRIPTION
Hi.

I've been using yt-sane for a really long while and the last month or two I haven't been able to list videos at all via the working copy now on the web.

So I forked and looked into the problem and found that if I changed the $scope.video.\* values to $scope.video.value.\* inside the item.html template as well as changing the link value in main.js and checked if we actually got a duration to the duration convertion function then I got a list again so I could watch my subscribed videos again.

I don't know if this pull request helps your development in any way but I thought I'll make it so the community could benifit from a working copy.

I'm look into learning angular one of these days so if you want I could try to help you in future development. Kind of hard at the moment though because I don't know the direction of the project or what issue to tackle.

Keep up the great work.

Best regards
Daniel
